### PR TITLE
store: Improved the lockers

### DIFF
--- a/store/players.go
+++ b/store/players.go
@@ -100,11 +100,11 @@ func (ps *Players) Reduce(state, a interface{}) interface{} {
 		return state
 	}
 
-	ps.mxPlayers.Lock()
-	defer ps.mxPlayers.Unlock()
-
 	switch act.Type {
 	case action.AddPlayer:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pstate.Players[act.AddPlayer.ID] = &Player{
 			ID:     act.AddPlayer.ID,
 			Name:   act.AddPlayer.Name,
@@ -114,8 +114,14 @@ func (ps *Players) Reduce(state, a interface{}) interface{} {
 			Gold:   40,
 		}
 	case action.RemovePlayer:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		delete(pstate.Players, act.RemovePlayer.ID)
 	case action.StealLive:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		fp := pstate.Players[act.StealLive.FromPlayerID]
 		fp.Lives -= 1
 		if fp.Lives < 0 {
@@ -139,9 +145,15 @@ func (ps *Players) Reduce(state, a interface{}) interface{} {
 			tp.Winner = true
 		}
 	case action.SummonUnit:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pstate.Players[act.SummonUnit.PlayerID].Income += unit.Units[act.SummonUnit.Type].Income
 		pstate.Players[act.SummonUnit.PlayerID].Gold -= unit.Units[act.SummonUnit.Type].Gold
 	case action.IncomeTick:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pstate.IncomeTimer -= 1
 		if pstate.IncomeTimer == 0 {
 			pstate.IncomeTimer = incomeTimer
@@ -150,14 +162,29 @@ func (ps *Players) Reduce(state, a interface{}) interface{} {
 			}
 		}
 	case action.PlaceTower:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pstate.Players[act.PlaceTower.PlayerID].Gold -= tower.Towers[act.PlaceTower.Type].Gold
 	case action.RemoveTower:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pstate.Players[act.RemoveTower.PlayerID].Gold += tower.Towers[act.RemoveTower.TowerType].Gold / 2
 	case action.PlayerReady:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pstate.Players[act.PlayerReady.ID].Ready = true
 	case action.UnitKilled:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pstate.Players[act.UnitKilled.PlayerID].Gold += unit.Units[act.UnitKilled.UnitType].Income
 	case action.UpdateState:
+		ps.mxPlayers.Lock()
+		defer ps.mxPlayers.Unlock()
+
 		pids := make(map[string]struct{})
 		for id := range pstate.Players {
 			pids[id] = struct{}{}

--- a/store/towers.go
+++ b/store/towers.go
@@ -72,11 +72,11 @@ func (ts *Towers) Reduce(state, a interface{}) interface{} {
 		return state
 	}
 
-	ts.mxTowers.Lock()
-	defer ts.mxTowers.Unlock()
-
 	switch act.Type {
 	case action.PlaceTower:
+		ts.mxTowers.Lock()
+		defer ts.mxTowers.Unlock()
+
 		p := ts.store.Players.GetPlayerByID(act.PlaceTower.PlayerID)
 
 		var w, h float64 = 16 * 2, 16 * 2
@@ -92,6 +92,9 @@ func (ts *Towers) Reduce(state, a interface{}) interface{} {
 			PlayerID: p.ID,
 		}
 	case action.UpdateState:
+		ts.mxTowers.Lock()
+		defer ts.mxTowers.Unlock()
+
 		tids := make(map[string]struct{})
 		for id := range tstate.Towers {
 			tids[id] = struct{}{}
@@ -105,14 +108,19 @@ func (ts *Towers) Reduce(state, a interface{}) interface{} {
 			delete(tstate.Towers, id)
 		}
 	case action.RemovePlayer:
+		ts.mxTowers.Lock()
+		defer ts.mxTowers.Unlock()
+
 		for id, t := range tstate.Towers {
 			if t.PlayerID == act.RemovePlayer.ID {
 				delete(tstate.Towers, id)
 			}
 		}
 	case action.RemoveTower:
+		ts.mxTowers.Lock()
+		defer ts.mxTowers.Unlock()
+
 		delete(tstate.Towers, act.RemoveTower.TowerID)
-	default:
 	}
 	return tstate
 }

--- a/store/units.go
+++ b/store/units.go
@@ -79,11 +79,11 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 		return state
 	}
 
-	us.mxUnits.Lock()
-	defer us.mxUnits.Unlock()
-
 	switch act.Type {
 	case action.SummonUnit:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		// We wait for the towers store as we need to interact with it
 		us.GetDispatcher().WaitFor(us.store.Towers.GetDispatcherToken())
 		var w, h float64 = 16, 16
@@ -114,6 +114,9 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 		u.Path = us.Astar(us.store.Map, u.CurrentLineID, u.MovingObject, tws)
 		ustate.Units[uid.String()] = u
 	case action.MoveUnit:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		for _, u := range ustate.Units {
 			if len(u.Path) > 0 {
 				nextStep := u.Path[0]
@@ -125,6 +128,9 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 			}
 		}
 	case action.PlaceTower:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		// We wait for the towers store as we need to interact with it
 		us.GetDispatcher().WaitFor(us.store.Towers.GetDispatcherToken())
 		ts := us.store.Towers.GetState().(TowersState)
@@ -144,6 +150,9 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 			}
 		}
 	case action.RemoveTower:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		// We wait for the towers store as we need to interact with it
 		us.GetDispatcher().WaitFor(us.store.Towers.GetDispatcherToken())
 		ts := us.store.Towers.GetTowers()
@@ -163,8 +172,14 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 			}
 		}
 	case action.RemoveUnit:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		delete(ustate.Units, act.RemoveUnit.UnitID)
 	case action.TowerAttack:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		u, ok := ustate.Units[act.TowerAttack.UnitID]
 		if !ok {
 			break
@@ -174,6 +189,9 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 			u.Health = 0
 		}
 	case action.UpdateState:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		uids := make(map[string]struct{})
 		for id := range ustate.Units {
 			uids[id] = struct{}{}
@@ -187,12 +205,14 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 			delete(ustate.Units, id)
 		}
 	case action.RemovePlayer:
+		us.mxUnits.Lock()
+		defer us.mxUnits.Unlock()
+
 		for id, u := range ustate.Units {
 			if u.PlayerID == act.RemovePlayer.ID {
 				delete(ustate.Units, id)
 			}
 		}
-	default:
 	}
 	return ustate
 }


### PR DESCRIPTION
Instead of locking on the 'Reduce' function (which is less repetitive) we lock on the action because if not we are always locking on all the actions (the 'Reduce' function is always called) so when doing it on the actions we only lock when we are actually making use of the map and need it