### PR TITLE
store/units: Added a HashPath on the Unit

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -76,9 +76,7 @@ func NewMoveUnit() *Action {
 	}
 }
 
-type RemoveUnitPayload struct {
-	UnitID string
-}
+type RemoveUnitPayload struct{ UnitID string }
 
 func NewRemoveUnit(uid string) *Action {
 	return &Action{
@@ -423,7 +421,8 @@ type UpdateStateUnitPayload struct {
 
 	Health float64
 
-	Path []utils.Step
+	Path     []utils.Step
+	HashPath string
 }
 
 // TODO: or make the action.Action separated or make the store.Player separated

--- a/store/reduce_test.go
+++ b/store/reduce_test.go
@@ -87,6 +87,7 @@ func TestSummonUnit(t *testing.T) {
 
 		// We need to set the path after the X, Y are set
 		eu.Path = s.Units.Astar(s.Map, clid, eu.MovingObject, nil)
+		eu.HashPath = utils.HashSteps(eu.Path)
 
 		// AS the Unit is created we remove it from the gold
 		// and add more income

--- a/store/units_test.go
+++ b/store/units_test.go
@@ -55,5 +55,6 @@ func TestUnits_List(t *testing.T) {
 	}
 	// We calculate the path also
 	eunits[0].Path = us.Astar(st.Map, clid, eunits[0].MovingObject, nil)
+	eunits[0].HashPath = utils.HashSteps(eunits[0].Path)
 	assert.Equal(t, eunits, units)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
 	"math"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -61,6 +64,10 @@ type Step struct {
 	Facing ebiten.Key
 }
 
+func (s Step) String() string {
+	return fmt.Sprintf("X:%f, Y:%f, W:%f, H:%f, F:%s", s.X, s.Y, s.W, s.H, s.Facing.String())
+}
+
 // NeighborSteps returns all the possible steps around the o
 func (o Object) NeighborSteps() []Step {
 	return []Step{
@@ -107,4 +114,12 @@ type MovingObject struct {
 
 	Facing      ebiten.Key
 	MovingCount int
+}
+
+func HashSteps(ss []Step) string {
+	var buffer bytes.Buffer
+	for _, s := range ss {
+		buffer.WriteString(s.String())
+	}
+	return fmt.Sprintf("%x", (sha256.Sum256([]byte(buffer.String()))))
 }


### PR DESCRIPTION
This Hash contains a hash of the Path so we can compare if we need to replace it when updating the client with the new State or keep the old one. The reason is that the client is normally faster that the server and so if we just replace the server value to the client we see some flickering related to every time the state is set from the sever as the units go back

Closes #63 