### PR TITLE
store/units: Have the units movement rely 100% on the server

### DIFF
--- a/server/new.go
+++ b/server/new.go
@@ -182,7 +182,6 @@ func startLoop(ctx context.Context, s *Store) {
 	for {
 		select {
 		case <-stateTicker.C:
-			// TODO: Send state
 			actionDispatcher.UpdateState(s.Rooms)
 		case <-incomeTicker.C:
 			actionDispatcher.IncomeTick(s.Rooms)

--- a/store/units.go
+++ b/store/units.go
@@ -85,6 +85,7 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 
 	switch act.Type {
 	case action.SummonUnit:
+		// We wait for the towers store as we need to interact with it
 		us.GetDispatcher().WaitFor(
 			us.store.Towers.GetDispatcherToken(),
 		)
@@ -95,7 +96,7 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 		if !p.CanSummonUnit(act.SummonUnit.Type) {
 			break
 		}
-		// We wait for the towers store as we need to interact with it
+
 		var w, h float64 = 16, 16
 		var x, y float64 = us.store.Map.GetRandomSpawnCoordinatesForLineID(act.SummonUnit.CurrentLineID)
 		uid := uuid.Must(uuid.NewV4())
@@ -247,16 +248,7 @@ func (us *Units) Reduce(state, a interface{}) interface{} {
 		for id, u := range act.UpdateState.Units.Units {
 			delete(uids, id)
 			nu := Unit(*u)
-			ou, ok := ustate.Units[id]
 
-			if ok {
-				if ou.HashPath == nu.HashPath {
-					nu.Path = ou.Path
-				}
-			}
-
-			// If the path is the same we set it. This cannot be done directly
-			// as the Unit on the client may be faster than the Unit on the server
 			ustate.Units[id] = &nu
 		}
 		for id := range uids {


### PR DESCRIPTION
For some reason the flickering was related to the server units beeing slower than the client units, ideally the HashPath checking was doing so the units Path could be just calculated on the client so it would run more smothely.

For some reason I was not able to find the root of the issue so as of now the units are fully controlled by the server, meaning that on every TPS the unit is on the position in which the server things it it.

Which is not bad by itself

Close #111 