### PR TITLE
mod: Remove the unintenioal lib

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Build
       run: make build

--- a/client/action.go
+++ b/client/action.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/sagikazarmark/slog-shim"
 	"github.com/xescugc/go-flux"
 	"github.com/xescugc/maze-wars/action"
 	"github.com/xescugc/maze-wars/store"

--- a/client/wasm/main.go
+++ b/client/wasm/main.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"log/slog"
 	"syscall/js"
 
-	"github.com/sagikazarmark/slog-shim"
 	"github.com/xescugc/go-flux"
 	"github.com/xescugc/maze-wars/client"
 	"github.com/xescugc/maze-wars/store"

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path"
 
 	"github.com/adrg/xdg"
-	"github.com/sagikazarmark/slog-shim"
 	"github.com/spf13/cobra"
 	"github.com/xescugc/go-flux"
 	"github.com/xescugc/maze-wars/client"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/adrg/xdg"
-	"github.com/sagikazarmark/slog-shim"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/xescugc/go-flux"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/hajimehoshi/ebiten/v2 v2.6.4
-	github.com/sagikazarmark/slog-shim v0.1.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.1
 	github.com/stretchr/testify v1.8.4
@@ -32,6 +31,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
+	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"context"
 	"io/ioutil"
+	"log/slog"
 	"os"
 	"os/exec"
 	"runtime"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/sagikazarmark/slog-shim"
 	"github.com/stretchr/testify/require"
 	"github.com/xescugc/go-flux"
 	"github.com/xescugc/maze-wars/client"

--- a/server/action.go
+++ b/server/action.go
@@ -3,9 +3,9 @@ package server
 import (
 	"context"
 	"log"
+	"log/slog"
 	"time"
 
-	"github.com/sagikazarmark/slog-shim"
 	"github.com/xescugc/go-flux"
 	"github.com/xescugc/maze-wars/action"
 	"github.com/xescugc/maze-wars/store"


### PR DESCRIPTION
Just used 'slog' and did not check the import, and it was not the std one but a package one so we can remove that and use the std one