### PR TITLE
client/images: Created an immemory cache for images

### DIFF
--- a/client/hud.go
+++ b/client/hud.go
@@ -279,7 +279,7 @@ func (hs *HUDStore) Draw(screen *ebiten.Image) {
 			op.ColorM.Scale(2, 0.5, 0.5, 0.9)
 		}
 
-		screen.DrawImage(ebiten.NewImageFromImage(hst.SelectedTower.Faceset()), op)
+		screen.DrawImage(imagesCache.Get(hst.SelectedTower.FacetKey()), op)
 	}
 }
 
@@ -631,7 +631,7 @@ func (hs *HUDStore) buildUI() {
 			),
 
 			// specify the images to sue
-			widget.ButtonOpts.Image(buttonImageFromImage(u.Faceset)),
+			widget.ButtonOpts.Image(buttonImageFromImage(imagesCache.Get(u.FacesetKey()))),
 
 			// add a handler that reacts to clicking the button
 			widget.ButtonOpts.ClickedHandler(func(u *unit.Unit) func(args *widget.ButtonClickedEventArgs) {
@@ -699,7 +699,7 @@ func (hs *HUDStore) buildUI() {
 			),
 
 			// specify the images to sue
-			widget.ButtonOpts.Image(buttonImageFromImage(t.Faceset)),
+			widget.ButtonOpts.Image(buttonImageFromImage(imagesCache.Get(t.FacesetKey()))),
 
 			// add a handler that reacts to clicking the button
 			widget.ButtonOpts.ClickedHandler(func(t *tower.Tower) func(args *widget.ButtonClickedEventArgs) {

--- a/client/images.go
+++ b/client/images.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/xescugc/maze-wars/store"
+	"github.com/xescugc/maze-wars/tower"
+	"github.com/xescugc/maze-wars/unit"
+)
+
+var (
+	imagesCache *ImagesCache
+)
+
+// ImagesCache is a simple cache for all the images, so instead
+// of running 'ebiten.NewImageFromImage' we just ran it once
+// and reuse it all the time
+type ImagesCache struct {
+	images map[string]*ebiten.Image
+}
+
+func init() {
+	imagesCache = &ImagesCache{
+		images: make(map[string]*ebiten.Image),
+	}
+
+	for _, u := range unit.Units {
+		imagesCache.images[u.FacesetKey()] = ebiten.NewImageFromImage(u.Faceset)
+		imagesCache.images[u.SpriteKey()] = ebiten.NewImageFromImage(u.Sprite)
+	}
+	for _, t := range tower.Towers {
+		imagesCache.images[t.FacesetKey()] = ebiten.NewImageFromImage(t.Faceset)
+	}
+	for i, m := range store.MapImages {
+		imagesCache.images[fmt.Sprintf(store.MapImageKeyFmt, i)] = ebiten.NewImageFromImage(m)
+	}
+}
+
+// Get will return the image from 'key', if it does not
+// exists a 'nil' will be returned
+func (i *ImagesCache) Get(key string) *ebiten.Image {
+	ei, _ := i.images[key]
+
+	return ei
+}

--- a/client/lines.go
+++ b/client/lines.go
@@ -133,7 +133,7 @@ func (ls *Lines) DrawTower(screen *ebiten.Image, c *CameraStore, t *store.Tower)
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(t.X-cs.X, t.Y-cs.Y)
 	op.GeoM.Scale(cs.Zoom, cs.Zoom)
-	screen.DrawImage(ebiten.NewImageFromImage(t.Faceset()), op)
+	screen.DrawImage(imagesCache.Get(t.FacetKey()), op)
 
 	if t.ID == hst.TowerOpenMenuID {
 		op := &ebiten.DrawImageOptions{}
@@ -159,7 +159,7 @@ func (ls *Lines) DrawUnit(screen *ebiten.Image, c *CameraStore, u *store.Unit) {
 	sx := directionToTile[u.Facing] * int(u.W)
 	i := (u.MovingCount / 5) % 4
 	sy := i * int(u.H)
-	screen.DrawImage(ebiten.NewImageFromImage(u.Sprite()).SubImage(image.Rect(sx, sy, sx+int(u.W), sy+int(u.H))).(*ebiten.Image), op)
+	screen.DrawImage(imagesCache.Get(u.SpriteKey()).SubImage(image.Rect(sx, sy, sx+int(u.W), sy+int(u.H))).(*ebiten.Image), op)
 
 	// Only draw the Health bar if the unit has been hit
 	h := unit.Units[u.Type].Health

--- a/client/map.go
+++ b/client/map.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/xescugc/maze-wars/store"
 	"github.com/xescugc/maze-wars/utils"
 )
 
@@ -41,8 +40,7 @@ func (m *Map) Draw(screen *ebiten.Image) {
 	s := m.game.Camera.GetState().(CameraState)
 	op.GeoM.Scale(s.Zoom, s.Zoom)
 	inverseZoom := maxZoom - s.Zoom + zoomScale
-	mi := ebiten.NewImageFromImage(m.game.Store.Map.GetState().(store.MapState).Image)
-	screen.DrawImage(mi.SubImage(image.Rect(int(s.X), int(s.Y), int((s.X+s.W)*inverseZoom), int((s.Y+s.H)*inverseZoom))).(*ebiten.Image), op)
+	screen.DrawImage(imagesCache.Get(m.game.Store.Map.GetImageKey()).SubImage(image.Rect(int(s.X), int(s.Y), int((s.X+s.W)*inverseZoom), int((s.Y+s.H)*inverseZoom))).(*ebiten.Image), op)
 
 	cs := m.game.Camera.GetState().(CameraState)
 	cp := m.game.Store.Players.FindCurrent()

--- a/client/sign_up.go
+++ b/client/sign_up.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"image"
 	"image/color"
 	"log/slog"
 	"time"
@@ -244,16 +243,15 @@ func loadButtonImage() (*widget.ButtonImage, error) {
 	}, nil
 }
 
-func buttonImageFromImage(i image.Image) *widget.ButtonImage {
-	ei := ebiten.NewImageFromImage(i)
-	nsi := euiimage.NewNineSliceSimple(ei, i.Bounds().Dx(), i.Bounds().Dy())
+func buttonImageFromImage(i *ebiten.Image) *widget.ButtonImage {
+	nsi := euiimage.NewNineSliceSimple(i, i.Bounds().Dx(), i.Bounds().Dy())
 
-	dest := i
 	cm := colorm.ColorM{}
 	cm.Scale(2, 0.5, 0.5, 0.9)
-	edest := ebiten.NewImageFromImage(dest)
-	colorm.DrawImage(edest, ei, cm, nil)
-	dsi := euiimage.NewNineSliceSimple(edest, dest.Bounds().Dx(), dest.Bounds().Dy())
+
+	ni := ebiten.NewImage(i.Bounds().Dx(), i.Bounds().Dy())
+	colorm.DrawImage(ni, i, cm, nil)
+	dsi := euiimage.NewNineSliceSimple(ni, ni.Bounds().Dx(), ni.Bounds().Dy())
 	return &widget.ButtonImage{
 		Idle:     nsi,
 		Hover:    nsi,

--- a/server/action.go
+++ b/server/action.go
@@ -36,7 +36,7 @@ func NewActionDispatcher(d *flux.Dispatcher, l *slog.Logger, s *Store) *ActionDi
 // This should only be used from the WS Handler to forward server actions directly
 func (ac *ActionDispatcher) Dispatch(a *action.Action) {
 	b := time.Now()
-	defer utils.LogTime(ac.logger, b, "action dispatched", "action", a.Type)
+	defer utils.LogTime(ac.logger, b, "action dispatch", "action", a.Type)
 
 	switch a.Type {
 	case action.JoinWaitingRoom:

--- a/store/lines.go
+++ b/store/lines.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"image"
 	"sync"
 
 	"github.com/gofrs/uuid"
@@ -44,9 +43,7 @@ type Tower struct {
 	PlayerID string
 }
 
-func (t *Tower) Faceset() image.Image {
-	return tower.Towers[t.Type].Faceset
-}
+func (t *Tower) FacetKey() string { return tower.Towers[t.Type].FacesetKey() }
 
 type Unit struct {
 	utils.MovingObject
@@ -64,13 +61,8 @@ type Unit struct {
 	HashPath string
 }
 
-func (u *Unit) Faceset() image.Image {
-	return unit.Units[u.Type].Faceset
-}
-
-func (u *Unit) Sprite() image.Image {
-	return unit.Units[u.Type].Sprite
-}
+func (u *Unit) FacesetKey() string { return unit.Units[u.Type].FacesetKey() }
+func (u *Unit) SpriteKey() string  { return unit.Units[u.Type].SpriteKey() }
 
 func NewLines(d *flux.Dispatcher, s *Store) *Lines {
 	l := &Lines{

--- a/store/map.go
+++ b/store/map.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"log"
 
@@ -13,6 +14,8 @@ import (
 
 var (
 	MapImages = map[int]image.Image{}
+
+	MapImageKeyFmt = "m-%d"
 )
 
 func init() {
@@ -73,6 +76,12 @@ func (m *Map) GetX() int { return m.GetState().(MapState).Image.Bounds().Dx() }
 
 // GetY returns the max Y value of the map
 func (m *Map) GetY() int { return m.GetState().(MapState).Image.Bounds().Dy() }
+
+// GetY returns the max Y value of the map
+func (m *Map) GetImageKey() string {
+	pc := m.GetState().(MapState).Players
+	return fmt.Sprintf(MapImageKeyFmt, pc)
+}
 
 // GetNextLineID based on the map and max number of players
 // it returns the next one and when it reaches the end

--- a/tower/tower.go
+++ b/tower/tower.go
@@ -3,6 +3,7 @@ package tower
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"image"
 	"log"
 
@@ -20,6 +21,8 @@ type Tower struct {
 
 	Faceset image.Image
 }
+
+func (t *Tower) FacesetKey() string { return fmt.Sprintf("t-f-%s", t.Type) }
 
 var (
 	Towers map[string]*Tower

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -3,6 +3,7 @@ package unit
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"image"
 	"log"
 
@@ -21,6 +22,9 @@ type Unit struct {
 	Faceset image.Image
 	Sprite  image.Image
 }
+
+func (u *Unit) FacesetKey() string { return fmt.Sprintf("u-f-%s", u.Type) }
+func (u *Unit) SpriteKey() string  { return fmt.Sprintf("u-s-%s", u.Type) }
 
 var (
 	Units map[string]*Unit


### PR DESCRIPTION
So we do not have to initialize them all the times just do that once.

It was done like this before but on the separaton of 'clinet' and 'server' we move it back to this so now it's fixed

Closes #178 