### PR TITLE
store/lines: Made the TPS check if there is a time in it

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"time"
+
 	"github.com/xescugc/maze-wars/utils"
 	"github.com/xescugc/maze-wars/utils/graph"
 	"nhooyr.io/websocket"
@@ -27,6 +29,7 @@ type Action struct {
 	StartGame            *StartGamePayload            `json:"start_game,omitempty"`
 	GoHome               *GoHomePayload               `json:"go_home,omitempty"`
 	ToggleStats          *ToggleStatsPayload          `json:"toggle_stats,omitempty"`
+	TPS                  *TPSPayload                  `json:"tps,omitempty"`
 
 	OpenTowerMenu  *OpenTowerMenuPayload  `json:"open_tower_menu,omitempty"`
 	CloseTowerMenu *CloseTowerMenuPayload `json:"close_tower_menu,omitempty"`
@@ -79,9 +82,16 @@ func NewSummonUnit(t, pid string, plid, clid int) *Action {
 	}
 }
 
-func NewTPS() *Action {
+type TPSPayload struct {
+	Time time.Time
+}
+
+func NewTPS(t time.Time) *Action {
 	return &Action{
 		Type: TPS,
+		TPS: &TPSPayload{
+			Time: t,
+		},
 	}
 }
 
@@ -509,8 +519,9 @@ type SyncStateUnitPayload struct {
 
 	Health float64
 
-	Path     []graph.Step
-	HashPath string
+	Path      []graph.Step
+	HashPath  string
+	CreatedAt time.Time
 }
 
 // TODO: or make the action.Action separated or make the store.Player separated

--- a/client/game/action.go
+++ b/client/game/action.go
@@ -58,7 +58,7 @@ func (ac *ActionDispatcher) SummonUnit(unit, pid string, plid, clid int) {
 
 // TPS is the call for every TPS event
 func (ac *ActionDispatcher) TPS() {
-	tpsa := action.NewTPS()
+	tpsa := action.NewTPS(time.Time{})
 	ac.Dispatch(tpsa)
 }
 

--- a/server/action.go
+++ b/server/action.go
@@ -81,11 +81,6 @@ func (ac *ActionDispatcher) WaitRoomCountdownTick() {
 	ac.startGame()
 }
 
-func (ac *ActionDispatcher) TPS(rooms *RoomsStore) {
-	tpsa := action.NewTPS()
-	ac.Dispatch(tpsa)
-}
-
 func (ac *ActionDispatcher) UserSignUp(un string) {
 	ac.Dispatch(action.NewUserSignUp(un))
 }
@@ -103,6 +98,7 @@ func (ac *ActionDispatcher) UserSignOut(un string) {
 }
 
 func (ac *ActionDispatcher) SyncState(rooms *RoomsStore) {
+	ac.Dispatch(action.NewTPS(time.Now()))
 	rstate := rooms.GetState().(RoomsState)
 	for _, r := range rstate.Rooms {
 		if r.Name == rstate.CurrentWaitingRoom {

--- a/server/new.go
+++ b/server/new.go
@@ -180,7 +180,6 @@ func startLoop(ctx context.Context, s *Store) {
 	stateTicker := time.NewTicker(time.Second / 4)
 	// The default TPS on of Ebiten client if 60 so to
 	// emulate that we trigger the move action every TPS
-	tpsTicker := time.NewTicker(time.Second / 60)
 	usersTicker := time.NewTicker(5 * time.Second)
 	for {
 		select {
@@ -190,14 +189,11 @@ func startLoop(ctx context.Context, s *Store) {
 			actionDispatcher.IncomeTick(s.Rooms)
 			actionDispatcher.WaitRoomCountdownTick()
 			actionDispatcher.SyncWaitingRoom(s.Rooms)
-		case <-tpsTicker.C:
-			actionDispatcher.TPS(s.Rooms)
 		case <-usersTicker.C:
 			actionDispatcher.SyncUsers(s.Users)
 		case <-ctx.Done():
 			stateTicker.Stop()
 			secondTicker.Stop()
-			tpsTicker.Stop()
 			usersTicker.Stop()
 			goto FINISH
 		}


### PR DESCRIPTION
If so It'll compare the updated times to that time and check how much the units have to move.

This way we remove the TPS every 1/60s no the server side and we only calculate that once it's needed

Closes #123 