### PR TITLE
client/game/hud: Fixed the Win/Lose messages display

### DIFF
--- a/client/game/hud.go
+++ b/client/game/hud.go
@@ -327,12 +327,7 @@ func (hs *HUDStore) Draw(screen *ebiten.Image) {
 	if cp.Lives == 0 {
 		hs.winLoseTextW.Label = "YOU LOST"
 		hs.winLoseTextW.GetWidget().Visibility = widget.Visibility_Show
-	} else if hs.winLoseTextW.GetWidget().Visibility != widget.Visibility_Hide {
-		hs.winLoseTextW.Label = ""
-		hs.winLoseTextW.GetWidget().Visibility = widget.Visibility_Hide
-	}
-
-	if cp.Winner {
+	} else if cp.Winner {
 		hs.winLoseTextW.Label = "YOU WON!"
 		hs.winLoseTextW.GetWidget().Visibility = widget.Visibility_Show
 	} else if hs.winLoseTextW.GetWidget().Visibility != widget.Visibility_Hide {


### PR DESCRIPTION
When changed it to the 'ebitenui' logic, this was done incorrectly

Closes #233 