### PR TITLE
utils/graph: Rename 'AStar' to 'Path'

### DIFF
--- a/store/lines.go
+++ b/store/lines.go
@@ -786,7 +786,7 @@ func (ls *Lines) Reduce(state LinesState, act *action.Action) LinesState {
 			u.Hybrid(cp.Income, ls.findPlayerByLineID(act.SummonUnit.CurrentLineID).Income)
 		}
 
-		u.Path, u.TargetTowerID = l.Graph.AStar(u.X, u.Y, u.MovementSpeed, u.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, bu.Environment, u.HasAbility(ability.Attack), atScale, useCache)
+		u.Path, u.TargetTowerID = l.Graph.Path(u.X, u.Y, u.MovementSpeed, u.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, bu.Environment, u.HasAbility(ability.Attack), atScale, useCache)
 		u.HashPath = graph.HashSteps(u.Path)
 		l.Units[u.ID] = u
 	case action.TPS:
@@ -871,7 +871,7 @@ func (ls *Lines) recalculateLineUnitSteps(state LinesState, lid int, twID string
 		if u.HasAbility(ability.Attack) && ((twID == "" || u.TargetTowerID != twID) && len(u.Path) == 0) {
 			continue
 		}
-		u.Path, u.TargetTowerID = l.Graph.AStar(u.X, u.Y, u.MovementSpeed, u.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, unit.Units[u.Type].Environment, u.HasAbility(ability.Attack), atScale, useCache)
+		u.Path, u.TargetTowerID = l.Graph.Path(u.X, u.Y, u.MovementSpeed, u.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, unit.Units[u.Type].Environment, u.HasAbility(ability.Attack), atScale, useCache)
 		u.HashPath = graph.HashSteps(u.Path)
 	}
 }
@@ -1358,7 +1358,7 @@ func (ls *Lines) changeUnitLine(state LinesState, u *Unit, nlid int) {
 	u.X = float64(n.X)
 	u.Y = float64(n.Y)
 
-	u.Path, u.TargetTowerID = nl.Graph.AStar(u.X, u.Y, u.MovementSpeed, u.Facing, nl.Graph.DeathNode.X, nl.Graph.DeathNode.Y, unit.Units[u.Type].Environment, u.HasAbility(ability.Attack), atScale, useCache)
+	u.Path, u.TargetTowerID = nl.Graph.Path(u.X, u.Y, u.MovementSpeed, u.Facing, nl.Graph.DeathNode.X, nl.Graph.DeathNode.Y, unit.Units[u.Type].Environment, u.HasAbility(ability.Attack), atScale, useCache)
 	u.HashPath = graph.HashSteps(u.Path)
 
 	u.CreatedAt = time.Now()

--- a/store/reduce_test.go
+++ b/store/reduce_test.go
@@ -186,7 +186,7 @@ func TestSummonUnit(t *testing.T) {
 		eu.ID, eu.X, eu.Y = units[uid].ID, units[uid].X, units[uid].Y
 
 		// We need to set the path after the X, Y are set
-		eu.Path = l.Graph.AStar(eu.X, eu.Y, eu.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, unit.Units[eu.Type].Environment, atScale)
+		eu.Path = l.Graph.Path(eu.X, eu.Y, eu.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, unit.Units[eu.Type].Environment, atScale)
 		eu.HashPath = graph.HashSteps(eu.Path)
 
 		// As the Unit is created we remove it from the gold
@@ -461,7 +461,7 @@ func TestPlaceTower(t *testing.T) {
 		l.Towers[tw.ID] = &tw
 
 		l2 := ls.Lines[p2.LineID]
-		u.Path = l2.Graph.AStar(u.X, u.Y, u.Facing, l2.Graph.DeathNode.X, l2.Graph.DeathNode.Y, unit.Units[u.Type].Environment, atScale)
+		u.Path = l2.Graph.Path(u.X, u.Y, u.Facing, l2.Graph.DeathNode.X, l2.Graph.DeathNode.Y, unit.Units[u.Type].Environment, atScale)
 		u.HashPath = graph.HashSteps(u.Path)
 
 		l2.Units[u.ID] = &u
@@ -745,7 +745,7 @@ func TestChangeUnitLine(t *testing.T) {
 		u1.CreatedAt = units[uid].CreatedAt
 
 		// We need to set the path after the X, Y are set
-		u1.Path = l.Graph.AStar(u1.X, u1.Y, u1.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, unit.Units[u1.Type].Environment, atScale)
+		u1.Path = l.Graph.Path(u1.X, u1.Y, u1.Facing, l.Graph.DeathNode.X, l.Graph.DeathNode.Y, unit.Units[u1.Type].Environment, atScale)
 		u1.HashPath = graph.HashSteps(u1.Path)
 
 		ls.Lines[p3.LineID].Units[u1.ID] = &u1

--- a/utils/graph/graph.go
+++ b/utils/graph/graph.go
@@ -224,7 +224,7 @@ func (g *Graph) canAddTower(x, y, w, h int) ([]*Node, error) {
 
 	// In order for it to work we'll momentarily add the
 	// Tower to the graph and remove it afterwards so we
-	// can run AStar
+	// can run Path
 	for _, n := range nodes {
 		n.TowerID = "test"
 	}
@@ -236,7 +236,7 @@ func (g *Graph) canAddTower(x, y, w, h int) ([]*Node, error) {
 
 	// Validates that adding the tower will not block the path
 	// from top to bottom
-	steps, _ := g.AStar(float64(g.OffsetX), float64(g.OffsetY), basicTPS, utils.Down, g.DeathNode.X, g.DeathNode.Y, environment.Terrestrial, !isAttacker, !atScale, !useCache)
+	steps, _ := g.Path(float64(g.OffsetX), float64(g.OffsetY), basicTPS, utils.Down, g.DeathNode.X, g.DeathNode.Y, environment.Terrestrial, !isAttacker, !atScale, !useCache)
 	if len(steps) == 0 {
 		return nil, ErrInvalidBlockingPath
 	}

--- a/utils/graph/path.go
+++ b/utils/graph/path.go
@@ -40,12 +40,12 @@ type queueItem struct {
 	index  int
 }
 
-// AStar calculates the shortest path between between Source(sx,sy)
+// Path calculates the shortest path between between Source(sx,sy)
 // to Target(tx,ty) with the Movement Speed(ms) and starting on the Direction(d)
 // with W,H equal to the Scale in the designed Environment(env).
 // If atScale is true it'll return the 1:1 result, if not it'll return
 // the 1:Scale result
-func (g *Graph) AStar(sx, sy, ms float64, d utils.Direction, tx, ty int, env environment.Environment, isAttacker, atScale, useCache bool) (steps []Step, towerID string) {
+func (g *Graph) Path(sx, sy, ms float64, d utils.Direction, tx, ty int, env environment.Environment, isAttacker, atScale, useCache bool) (steps []Step, towerID string) {
 	nm := stepMap{}
 	nq := &queue{}
 	heap.Init(nq)

--- a/utils/graph/path_test.go
+++ b/utils/graph/path_test.go
@@ -15,7 +15,7 @@ const (
 	isAttacker = true
 )
 
-func TestGraph_AStar(t *testing.T) {
+func TestGraph_Path(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Run("DefaultTerrestrial", func(t *testing.T) {
 			g, err := graph.New(0, 0, 3, 3, 1, 1, 1, 1)
@@ -48,7 +48,7 @@ func TestGraph_AStar(t *testing.T) {
 			for _, s := range esteps {
 				enodes = append(enodes, g.GetNode(int(s.X), int(s.Y)))
 			}
-			steps, twid := g.AStar(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
+			steps, twid := g.Path(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -65,8 +65,8 @@ func TestGraph_AStar(t *testing.T) {
 			}
 
 			// There is no way for me to know if the NextStep logic is used
-			// so I'm gonna force another AStar so it uses it
-			steps, twid = g.AStar(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
+			// so I'm gonna force another Path so it uses it
+			steps, twid = g.Path(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -96,7 +96,7 @@ func TestGraph_AStar(t *testing.T) {
 			for _, s := range esteps {
 				enodes = append(enodes, g.GetNode(int(s.X), int(s.Y)))
 			}
-			steps, twid := g.AStar(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, isAttacker, !atScale)
+			steps, twid := g.Path(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, isAttacker, !atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -146,7 +146,7 @@ func TestGraph_AStar(t *testing.T) {
 					Facing: utils.Left,
 				},
 			}
-			steps, twid := g.AStar(0, 0, 30, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, atScale)
+			steps, twid := g.Path(0, 0, 30, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -154,8 +154,8 @@ func TestGraph_AStar(t *testing.T) {
 			assert.Empty(t, twid)
 
 			// There is no way for me to know if the NextStep logic is used
-			// so I'm gonna force another AStar so it uses it
-			steps, twid = g.AStar(0, 0, 30, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, atScale)
+			// so I'm gonna force another Path so it uses it
+			steps, twid = g.Path(0, 0, 30, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -185,7 +185,7 @@ func TestGraph_AStar(t *testing.T) {
 			for _, s := range esteps {
 				enodes = append(enodes, g.GetNode(int(s.X), int(s.Y)))
 			}
-			steps, twid := g.AStar(0, 0, 60, utils.Down, 0, 2, environment.Aerial, !isAttacker, !atScale)
+			steps, twid := g.Path(0, 0, 60, utils.Down, 0, 2, environment.Aerial, !isAttacker, !atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -243,7 +243,7 @@ func TestGraph_AStar(t *testing.T) {
 					Facing: utils.Left,
 				},
 			}
-			steps, twid := g.AStar(10, 10, 60, utils.Down, 10, 14, environment.Terrestrial, !isAttacker, atScale)
+			steps, twid := g.Path(10, 10, 60, utils.Down, 10, 14, environment.Terrestrial, !isAttacker, atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -293,7 +293,7 @@ func TestGraph_AStar(t *testing.T) {
 					Facing: utils.Left,
 				},
 			}
-			steps, twid := g.AStar(11, 10, 60, utils.Down, 10, 14, environment.Terrestrial, !isAttacker, atScale)
+			steps, twid := g.Path(11, 10, 60, utils.Down, 10, 14, environment.Terrestrial, !isAttacker, atScale)
 			require.NotNil(t, steps)
 			require.NotEmpty(t, steps)
 			require.Len(t, steps, len(esteps))
@@ -304,7 +304,7 @@ func TestGraph_AStar(t *testing.T) {
 			g, err := graph.New(0, 0, 3, 3, 1, 1, 1, 1)
 			require.NoError(t, err)
 
-			_, _ = g.AStar(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
+			_, _ = g.Path(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
 			g.AddTower("id", 0, 1, 1, 1)
 			for _, yn := range g.Nodes {
 				for _, n := range yn {
@@ -317,7 +317,7 @@ func TestGraph_AStar(t *testing.T) {
 			require.NoError(t, err)
 
 			g.AddTower("id", 0, 1, 1, 1)
-			_, _ = g.AStar(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
+			_, _ = g.Path(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
 			g.RemoveTower("id")
 			for _, yn := range g.Nodes {
 				for _, n := range yn {
@@ -357,7 +357,7 @@ func TestGraph_AStar(t *testing.T) {
 				enodes = append(enodes, g.GetNode(int(s.X), int(s.Y)))
 			}
 
-			steps, twid := g.AStar(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
+			steps, twid := g.Path(0, 0, 60, utils.Down, 0, 2, environment.Terrestrial, !isAttacker, !atScale)
 			g.RemoveTower("not-found")
 
 			require.NotNil(t, steps)

--- a/utils/graph/step.go
+++ b/utils/graph/step.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Step struct {
-	// Node is used to calculate the AStar of the Graph but should
+	// Node is used to calculate the Path of the Graph but should
 	// not be used to get the position of the step (X,Y) as it can
-	// be nil when the AStar has the flag 'AtScale'
+	// be nil when the Path has the flag 'AtScale'
 	Node *Node
 
 	X, Y float64


### PR DESCRIPTION
As we do no longer use AStar, is better to give it a more general name like 'Path'

Close #207 